### PR TITLE
fix: error handling

### DIFF
--- a/src/jarvis/jarvis/engines/stt.py
+++ b/src/jarvis/jarvis/engines/stt.py
@@ -51,9 +51,9 @@ class STTEngine:
             voice_transcript = self.speech_recognizer.recognize_google(audio_text).lower()
             self.logger.debug('Recognized words: ' + voice_transcript)
             return voice_transcript
-        except self.speech_recognizer.UnknownValueError:
+        except self.sr.UnknownValueError:
             self.logger.info('Not recognized text')
-        except self.speech_recognizer.RequestError:
+        except self.sr.RequestError:
             self.logger.info("Google API was unreachable.")
 
     def _record(self):


### PR DESCRIPTION
Object of type `Recognizer` has no attribute 'UnknownValueError' or
'RequestError' which was breaking the exception handling code.
This commit uses `self.sr` to get those attributes